### PR TITLE
Bump requirements to be compatible with Red 3.4.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,7 @@ mathparse
 python-dateutil
 sqlalchemy>=1.4.20
 pytz
-spacy>=3.0
+spacy>=3.1.3
 git+git://github.com/gunthercox/chatterbot-corpus@master#egg=chatterbot_corpus
+# this requirement for typer should be ditched once spacy stop supporting or red change and take in account installed lib version to install cogs deps
+typer>=0.4.0,<0.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ max_line_length = 175
 exclude = .eggs, .git, .tox, build,
 
 [chatterbot]
-version = 1.1.0.dev3
+version = 1.1.0.dev4
 author = Gunther Cox
 email = gunthercx@gmail.com
 url = https://github.com/gunthercox/ChatterBot


### PR DESCRIPTION
bump spacy + add typer as requirement to force v0.4 which is compatible with click v0.8, to be installed

Tested this on my bot and it's working fine, as of now, i haven't had any error.

(Typer v0.4 is compatible with click v7 and v8, so people who downgraded it to keep using chatter shouldn't have any problem) 